### PR TITLE
Enabling BindToFactory in Mono

### DIFF
--- a/src/Ninject.Extensions.Conventions.Test/IntegrationTests/FactoryTests.cs
+++ b/src/Ninject.Extensions.Conventions.Test/IntegrationTests/FactoryTests.cs
@@ -19,7 +19,7 @@
 // </copyright>
 //-------------------------------------------------------------------------------
 
-#if !SILVERLIGHT_20 && !WINDOWS_PHONE && !NETCF_35 && !MONO
+#if !SILVERLIGHT_20 && !WINDOWS_PHONE && !NETCF_35
 namespace Ninject.Extensions.Conventions.IntegrationTests
 {
     using System;

--- a/src/Ninject.Extensions.Conventions/BindingBuilder/BindingGeneratorFactory.cs
+++ b/src/Ninject.Extensions.Conventions/BindingBuilder/BindingGeneratorFactory.cs
@@ -28,7 +28,7 @@ namespace Ninject.Extensions.Conventions.BindingBuilder
     using Ninject.Components;
     using Ninject.Extensions.Conventions.BindingGenerators;
     using Ninject.Extensions.Conventions.Syntax;
-#if !SILVERLIGHT_20 && !WINDOWS_PHONE && !NETCF_35 && !MONO
+#if !SILVERLIGHT_20 && !WINDOWS_PHONE && !NETCF_35
     using Ninject.Extensions.Factory;
 #endif
 
@@ -140,7 +140,7 @@ namespace Ninject.Extensions.Conventions.BindingBuilder
             return new SelectorBindingGenerator(this.CreateSingleBindingCreator(), selector, this.bindableTypeSelector);
         }
 
-#if !SILVERLIGHT_20 && !WINDOWS_PHONE && !NETCF_35 && !MONO
+#if !SILVERLIGHT_20 && !WINDOWS_PHONE && !NETCF_35
         /// <summary>
         /// Creates a new FactoryBindingGenerator instance.
         /// </summary>

--- a/src/Ninject.Extensions.Conventions/BindingBuilder/ConventionSyntax.Bind.cs
+++ b/src/Ninject.Extensions.Conventions/BindingBuilder/ConventionSyntax.Bind.cs
@@ -26,7 +26,7 @@ namespace Ninject.Extensions.Conventions.BindingBuilder
 
     using Ninject.Extensions.Conventions.BindingGenerators;
     using Ninject.Extensions.Conventions.Syntax;
-#if !SILVERLIGHT_20 && !WINDOWS_PHONE && !NETCF_35 && !MONO
+#if !SILVERLIGHT_20 && !WINDOWS_PHONE && !NETCF_35
     using Ninject.Extensions.Factory;
 #endif
 
@@ -146,7 +146,7 @@ namespace Ninject.Extensions.Conventions.BindingBuilder
             return this.BindWith(this.bindingGeneratorFactory.CreateRegexBindingGenerator(pattern, options));
         }
 
-#if !SILVERLIGHT_20 && !WINDOWS_PHONE && !NETCF_35 && !MONO
+#if !SILVERLIGHT_20 && !WINDOWS_PHONE && !NETCF_35
         /// <summary>
         /// Binds interfaces to factory implementations using the factory extension.
         /// </summary>

--- a/src/Ninject.Extensions.Conventions/BindingBuilder/IBindingGeneratorFactory.cs
+++ b/src/Ninject.Extensions.Conventions/BindingBuilder/IBindingGeneratorFactory.cs
@@ -27,7 +27,7 @@ namespace Ninject.Extensions.Conventions.BindingBuilder
     using Ninject.Components;
     using Ninject.Extensions.Conventions.BindingGenerators;
     using Ninject.Extensions.Conventions.Syntax;
-#if !SILVERLIGHT_20 && !WINDOWS_PHONE && !NETCF_35 && !MONO
+#if !SILVERLIGHT_20 && !WINDOWS_PHONE && !NETCF_35
     using Ninject.Extensions.Factory;
 #endif
 
@@ -94,7 +94,7 @@ namespace Ninject.Extensions.Conventions.BindingBuilder
         /// <returns>The newly created generator.</returns>
         IBindingGenerator CreateSelectorBindingGenerator(ServiceSelector selector);
 
-#if !SILVERLIGHT_20 && !WINDOWS_PHONE && !NETCF_35 && !MONO
+#if !SILVERLIGHT_20 && !WINDOWS_PHONE && !NETCF_35
         /// <summary>
         /// Creates a new FactoryBindingGenerator instance.
         /// </summary>

--- a/src/Ninject.Extensions.Conventions/BindingGenerators/FactoryBindingGenerator.cs
+++ b/src/Ninject.Extensions.Conventions/BindingGenerators/FactoryBindingGenerator.cs
@@ -19,7 +19,7 @@
 // </copyright>
 //-------------------------------------------------------------------------------
 
-#if !SILVERLIGHT_20 && !WINDOWS_PHONE && !NETCF_35 && !MONO
+#if !SILVERLIGHT_20 && !WINDOWS_PHONE && !NETCF_35
 namespace Ninject.Extensions.Conventions.BindingGenerators
 {
     using System;

--- a/src/Ninject.Extensions.Conventions/Syntax/IBindSyntax.cs
+++ b/src/Ninject.Extensions.Conventions/Syntax/IBindSyntax.cs
@@ -26,7 +26,7 @@ namespace Ninject.Extensions.Conventions.Syntax
     using System.Text.RegularExpressions;
 
     using Ninject.Extensions.Conventions.BindingGenerators;
-#if !SILVERLIGHT_20 && !WINDOWS_PHONE && !NETCF_35 && !MONO
+#if !SILVERLIGHT_20 && !WINDOWS_PHONE && !NETCF_35
     using Ninject.Extensions.Factory;
 #endif
     using Ninject.Syntax;
@@ -121,7 +121,7 @@ namespace Ninject.Extensions.Conventions.Syntax
         /// <returns>The fluent syntax</returns>
         IConfigureSyntax BindUsingRegex(string pattern, RegexOptions options);
 
-#if !SILVERLIGHT_20 && !WINDOWS_PHONE && !NETCF_35 && !MONO
+#if !SILVERLIGHT_20 && !WINDOWS_PHONE && !NETCF_35
         /// <summary>
         /// Binds interfaces to factory implementations using the factory extension.
         /// </summary>


### PR DESCRIPTION
Enabled BindToFactory in Mono. Requires the updated factory extension I issued a pull request for.
