### PR TITLE
Add Bind<TInterface> syntax to bind a specific interface

### DIFF
--- a/ReleaseNotes.txt
+++ b/ReleaseNotes.txt
@@ -1,4 +1,14 @@
-Version 3.2.0
+Version 3.2.0.1
+-------------
+- Add: Support for specific service type binding IBindSyntax.Bind<
+  E.g.
+  kernel.Bind(x => x
+     .FromThisAssembly()
+	 .SelectAllClasses()
+	 .InheritedFrom<IFoo>()
+	 .Bind<IFoo>());
+
+Version 3.2.0.0
 -------------
 - Add: Support for multiple configurations in one BindWith
   E.g.

--- a/src/Ninject.Extensions.Conventions.Test/BindingBuilder/ConventionSyntaxBindingTests.cs
+++ b/src/Ninject.Extensions.Conventions.Test/BindingBuilder/ConventionSyntaxBindingTests.cs
@@ -22,6 +22,7 @@
 #if !NO_MOQ
 namespace Ninject.Extensions.Conventions.BindingBuilder
 {
+    using System;
     using System.Text.RegularExpressions;
     using Moq;
     using Ninject.Extensions.Conventions.BindingGenerators;
@@ -67,9 +68,37 @@ namespace Ninject.Extensions.Conventions.BindingBuilder
         }
 
         [Fact]
+        public void BindGeneric()
+        {
+            Type serviceType = typeof(string);
+            var generator = Mock.Of<IBindingGenerator>();
+            this.bindingGeneratorFactoryMock
+                .Setup(g => g.CreateSpecificTypesBindingGenerator(serviceType))
+                .Returns(generator);
+
+            this.testee.Bind<string>();
+
+            this.conventionBindingBuilderMock.Verify(b => b.BindWith(generator));
+        }
+
+        [Fact]
+        public void Bind()
+        {
+            Type[] serviceTypes = { typeof(string), typeof(object) };
+            var generator = Mock.Of<IBindingGenerator>();
+            this.bindingGeneratorFactoryMock
+                .Setup(g => g.CreateSpecificTypesBindingGenerator(serviceTypes))
+                .Returns(generator);
+
+            this.testee.Bind(serviceTypes);
+
+            this.conventionBindingBuilderMock.Verify(b => b.BindWith(generator));
+        }
+
+        [Fact]
         public void BindToAllInterfaces()
         {
-            var generator = new Mock<IBindingGenerator>().Object;
+            var generator = Mock.Of<IBindingGenerator>();
             this.bindingGeneratorFactoryMock.Setup(g => g.CreateAllInterfacesBindingGenerator()).Returns(generator);
 
             this.testee.BindAllInterfaces();
@@ -80,7 +109,7 @@ namespace Ninject.Extensions.Conventions.BindingBuilder
         [Fact]
         public void BindToAllBaseClasses()
         {
-            var generator = new Mock<IBindingGenerator>().Object;
+            var generator = Mock.Of<IBindingGenerator>();
             this.bindingGeneratorFactoryMock.Setup(g => g.CreateAllBaseClassesBindingGenerator()).Returns(generator);
 
             this.testee.BindAllBaseClasses();
@@ -91,7 +120,7 @@ namespace Ninject.Extensions.Conventions.BindingBuilder
         [Fact]
         public void BindToBase()
         {
-            var generator = new Mock<IBindingGenerator>().Object;
+            var generator = Mock.Of<IBindingGenerator>();
             this.bindingGeneratorFactoryMock.Setup(g => g.CreateBaseBindingGenerator()).Returns(generator);
 
             this.testee.BindBase();
@@ -102,7 +131,7 @@ namespace Ninject.Extensions.Conventions.BindingBuilder
         [Fact]
         public void BindToDefaultInterface()
         {
-            var generator = new Mock<IBindingGenerator>().Object;
+            var generator = Mock.Of<IBindingGenerator>();
             this.bindingGeneratorFactoryMock.Setup(g => g.CreateDefaultInterfaceBindingGenerator()).Returns(generator);
 
             this.testee.BindDefaultInterface();
@@ -113,7 +142,7 @@ namespace Ninject.Extensions.Conventions.BindingBuilder
         [Fact]
         public void BindToDefaultInterfaces()
         {
-            var generator = new Mock<IBindingGenerator>().Object;
+            var generator = Mock.Of<IBindingGenerator>();
             this.bindingGeneratorFactoryMock.Setup(g => g.CreateDefaultInterfacesBindingGenerator()).Returns(generator);
 
             this.testee.BindDefaultInterfaces();
@@ -124,7 +153,7 @@ namespace Ninject.Extensions.Conventions.BindingBuilder
         [Fact]
         public void BindToSelf()
         {
-            var generator = new Mock<IBindingGenerator>().Object;
+            var generator = Mock.Of<IBindingGenerator>();
             this.bindingGeneratorFactoryMock.Setup(g => g.CreateSelfBindingGenerator()).Returns(generator);
 
             this.testee.BindToSelf();
@@ -135,7 +164,7 @@ namespace Ninject.Extensions.Conventions.BindingBuilder
         [Fact]
         public void BindToSingleInterface()
         {
-            var generator = new Mock<IBindingGenerator>().Object;
+            var generator = Mock.Of<IBindingGenerator>();
             this.bindingGeneratorFactoryMock.Setup(g => g.CreateSingleInterfaceBindingGenerator()).Returns(generator);
 
             this.testee.BindSingleInterface();
@@ -147,7 +176,7 @@ namespace Ninject.Extensions.Conventions.BindingBuilder
         public void BindToSelection()
         {
             ServiceSelector selector = (t1, t2) => t2;
-            var generator = new Mock<IBindingGenerator>().Object;
+            var generator = Mock.Of<IBindingGenerator>();
             this.bindingGeneratorFactoryMock.Setup(g => g.CreateSelectorBindingGenerator(selector)).Returns(generator);
 
             this.testee.BindSelection(selector);
@@ -159,7 +188,7 @@ namespace Ninject.Extensions.Conventions.BindingBuilder
         public void BindToRegex()
         {
             const string Pattern = "ThePattern";
-            var generator = new Mock<IBindingGenerator>().Object;
+            var generator = Mock.Of<IBindingGenerator>();
             this.bindingGeneratorFactoryMock.Setup(g => g.CreateRegexBindingGenerator(Pattern)).Returns(generator);
 
             this.testee.BindUsingRegex(Pattern);
@@ -172,7 +201,7 @@ namespace Ninject.Extensions.Conventions.BindingBuilder
         {
             const string Pattern = "ThePattern";
             const RegexOptions Options = RegexOptions.Multiline;
-            var generator = new Mock<IBindingGenerator>().Object;
+            var generator = Mock.Of<IBindingGenerator>();
             this.bindingGeneratorFactoryMock.Setup(g => g.CreateRegexBindingGenerator(Pattern, Options)).Returns(generator);
 
             this.testee.BindUsingRegex(Pattern, Options);

--- a/src/Ninject.Extensions.Conventions.Test/BindingBuilder/ConventionSyntaxBindingTests.cs
+++ b/src/Ninject.Extensions.Conventions.Test/BindingBuilder/ConventionSyntaxBindingTests.cs
@@ -71,7 +71,7 @@ namespace Ninject.Extensions.Conventions.BindingBuilder
         public void BindGeneric()
         {
             Type serviceType = typeof(string);
-            var generator = Mock.Of<IBindingGenerator>();
+            var generator = new Mock<IBindingGenerator>().Object;
             this.bindingGeneratorFactoryMock
                 .Setup(g => g.CreateSpecificTypesBindingGenerator(serviceType))
                 .Returns(generator);
@@ -85,7 +85,7 @@ namespace Ninject.Extensions.Conventions.BindingBuilder
         public void Bind()
         {
             Type[] serviceTypes = { typeof(string), typeof(object) };
-            var generator = Mock.Of<IBindingGenerator>();
+            var generator = new Mock<IBindingGenerator>().Object;
             this.bindingGeneratorFactoryMock
                 .Setup(g => g.CreateSpecificTypesBindingGenerator(serviceTypes))
                 .Returns(generator);
@@ -98,7 +98,7 @@ namespace Ninject.Extensions.Conventions.BindingBuilder
         [Fact]
         public void BindToAllInterfaces()
         {
-            var generator = Mock.Of<IBindingGenerator>();
+            var generator = new Mock<IBindingGenerator>().Object;
             this.bindingGeneratorFactoryMock.Setup(g => g.CreateAllInterfacesBindingGenerator()).Returns(generator);
 
             this.testee.BindAllInterfaces();
@@ -109,7 +109,7 @@ namespace Ninject.Extensions.Conventions.BindingBuilder
         [Fact]
         public void BindToAllBaseClasses()
         {
-            var generator = Mock.Of<IBindingGenerator>();
+            var generator = new Mock<IBindingGenerator>().Object;
             this.bindingGeneratorFactoryMock.Setup(g => g.CreateAllBaseClassesBindingGenerator()).Returns(generator);
 
             this.testee.BindAllBaseClasses();
@@ -120,7 +120,7 @@ namespace Ninject.Extensions.Conventions.BindingBuilder
         [Fact]
         public void BindToBase()
         {
-            var generator = Mock.Of<IBindingGenerator>();
+            var generator = new Mock<IBindingGenerator>().Object;
             this.bindingGeneratorFactoryMock.Setup(g => g.CreateBaseBindingGenerator()).Returns(generator);
 
             this.testee.BindBase();
@@ -131,7 +131,7 @@ namespace Ninject.Extensions.Conventions.BindingBuilder
         [Fact]
         public void BindToDefaultInterface()
         {
-            var generator = Mock.Of<IBindingGenerator>();
+            var generator = new Mock<IBindingGenerator>().Object;
             this.bindingGeneratorFactoryMock.Setup(g => g.CreateDefaultInterfaceBindingGenerator()).Returns(generator);
 
             this.testee.BindDefaultInterface();
@@ -142,7 +142,7 @@ namespace Ninject.Extensions.Conventions.BindingBuilder
         [Fact]
         public void BindToDefaultInterfaces()
         {
-            var generator = Mock.Of<IBindingGenerator>();
+            var generator = new Mock<IBindingGenerator>().Object;
             this.bindingGeneratorFactoryMock.Setup(g => g.CreateDefaultInterfacesBindingGenerator()).Returns(generator);
 
             this.testee.BindDefaultInterfaces();
@@ -153,7 +153,7 @@ namespace Ninject.Extensions.Conventions.BindingBuilder
         [Fact]
         public void BindToSelf()
         {
-            var generator = Mock.Of<IBindingGenerator>();
+            var generator = new Mock<IBindingGenerator>().Object;
             this.bindingGeneratorFactoryMock.Setup(g => g.CreateSelfBindingGenerator()).Returns(generator);
 
             this.testee.BindToSelf();
@@ -164,7 +164,7 @@ namespace Ninject.Extensions.Conventions.BindingBuilder
         [Fact]
         public void BindToSingleInterface()
         {
-            var generator = Mock.Of<IBindingGenerator>();
+            var generator = new Mock<IBindingGenerator>().Object;
             this.bindingGeneratorFactoryMock.Setup(g => g.CreateSingleInterfaceBindingGenerator()).Returns(generator);
 
             this.testee.BindSingleInterface();
@@ -176,7 +176,7 @@ namespace Ninject.Extensions.Conventions.BindingBuilder
         public void BindToSelection()
         {
             ServiceSelector selector = (t1, t2) => t2;
-            var generator = Mock.Of<IBindingGenerator>();
+            var generator = new Mock<IBindingGenerator>().Object;
             this.bindingGeneratorFactoryMock.Setup(g => g.CreateSelectorBindingGenerator(selector)).Returns(generator);
 
             this.testee.BindSelection(selector);
@@ -188,7 +188,7 @@ namespace Ninject.Extensions.Conventions.BindingBuilder
         public void BindToRegex()
         {
             const string Pattern = "ThePattern";
-            var generator = Mock.Of<IBindingGenerator>();
+            var generator = new Mock<IBindingGenerator>().Object;
             this.bindingGeneratorFactoryMock.Setup(g => g.CreateRegexBindingGenerator(Pattern)).Returns(generator);
 
             this.testee.BindUsingRegex(Pattern);
@@ -201,7 +201,7 @@ namespace Ninject.Extensions.Conventions.BindingBuilder
         {
             const string Pattern = "ThePattern";
             const RegexOptions Options = RegexOptions.Multiline;
-            var generator = Mock.Of<IBindingGenerator>();
+            var generator = new Mock<IBindingGenerator>().Object;
             this.bindingGeneratorFactoryMock.Setup(g => g.CreateRegexBindingGenerator(Pattern, Options)).Returns(generator);
 
             this.testee.BindUsingRegex(Pattern, Options);

--- a/src/Ninject.Extensions.Conventions.Test/BindingGenerators/SpecificTypesBindingGeneratorTests.cs
+++ b/src/Ninject.Extensions.Conventions.Test/BindingGenerators/SpecificTypesBindingGeneratorTests.cs
@@ -1,0 +1,80 @@
+//-------------------------------------------------------------------------------
+// <copyright file="SingleInterfaceBindingGeneratorTests.cs" company="Ninject Project Contributors">
+//   Copyright (c) 2009-2011 Ninject Project Contributors
+//   Authors: Remo Gloor (remo.gloor@gmail.com)
+//           
+//   Dual-licensed under the Apache License, Version 2.0, and the Microsoft Public License (Ms-PL).
+//   you may not use this file except in compliance with one of the Licenses.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//   or
+//       http://www.microsoft.com/opensource/licenses.mspx
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+// </copyright>
+//-------------------------------------------------------------------------------
+
+#if !SILVERLIGHT_30 && !SILVERLIGHT_20 && !NO_MOQ && !NO_GENERIC_MOQ
+namespace Ninject.Extensions.Conventions.BindingGenerators
+{
+    using System;
+    using System.Linq;
+    using FluentAssertions;
+
+    using Ninject.Extensions.Conventions.BindingBuilder;
+    using Ninject.Extensions.Conventions.Fakes;
+    using Xunit;
+
+    public class SpecificTypesBindingGeneratorTests
+    {
+        private static readonly Type[] ServiceTypes = { typeof(IFoo), typeof(IBar), typeof(IService) };
+
+        private readonly IBindingGenerator testee;
+        private readonly KernelMock kernelMock;
+        
+        public SpecificTypesBindingGeneratorTests()
+        {
+            this.kernelMock = new KernelMock();
+            this.testee = new BindingGeneratorFactory(null).CreateSpecificTypesBindingGenerator(ServiceTypes);
+        }
+
+        [Fact]
+        public void ExceptionIsThrownWhenTypeDoesNotImplementServiceType()
+        {
+            var type = typeof(Foo);
+
+            var exception = Assert.Throws<InvalidOperationException>(() => this.testee.CreateBindings(type, this.kernelMock.Object).ToList());
+
+            exception.Message.Should()
+                .Contain(type.FullName)
+                .And.Contain(typeof(IBar).FullName)
+                .And.Contain(typeof(IService).FullName);
+        }
+
+        [Fact]
+        public void AllServiceTypesAreBound()
+        {
+            var type = typeof(MultipleInterfaceCrazyService);
+
+            this.testee.CreateBindings(type, this.kernelMock.Object).ToList();
+
+            this.kernelMock.VerifyBindingCreated(ServiceTypes, type);
+        }
+
+        [Fact]
+        public void SyntaxForBindingIsReturned()
+        {
+            var type = typeof(MultipleInterfaceCrazyService);
+
+            var syntax = this.testee.CreateBindings(type, this.kernelMock.Object).ToList();
+
+            syntax.Should().Contain(this.kernelMock.ReturnedSyntax);
+        }
+    }
+}
+#endif

--- a/src/Ninject.Extensions.Conventions.Test/BindingGenerators/SpecificTypesBindingGeneratorTests.cs
+++ b/src/Ninject.Extensions.Conventions.Test/BindingGenerators/SpecificTypesBindingGeneratorTests.cs
@@ -53,7 +53,8 @@ namespace Ninject.Extensions.Conventions.BindingGenerators
             exception.Message.Should()
                 .Contain(type.FullName)
                 .And.Contain(typeof(IBar).FullName)
-                .And.Contain(typeof(IService).FullName);
+                .And.Contain(typeof(IService).FullName)
+                .And.NotContain(typeof(IFoo).FullName);
         }
 
         [Fact]

--- a/src/Ninject.Extensions.Conventions.Test/Ninject.Extensions.Conventions.Tests.csproj
+++ b/src/Ninject.Extensions.Conventions.Test/Ninject.Extensions.Conventions.Tests.csproj
@@ -98,6 +98,7 @@
     <Compile Include="BindingBuilder\TypeSelectorTests.cs" />
     <Compile Include="BindingBuilder\TypeFilterTests.cs" />
     <Compile Include="BindingGenerators\AllBaseClassesBindingGeneratorTests.cs" />
+    <Compile Include="BindingGenerators\SpecificTypesBindingGeneratorTests.cs" />
     <Compile Include="BindingGenerators\TestBindingGeneratorFactory.cs" />
     <Compile Include="Fakes\AbstractInheritanceTree\BaseAbstractClass.cs" />
     <Compile Include="Fakes\AbstractInheritanceTree\DerivedAbstractClassImpl.cs" />

--- a/src/Ninject.Extensions.Conventions/BindingBuilder/BindingGeneratorFactory.cs
+++ b/src/Ninject.Extensions.Conventions/BindingBuilder/BindingGeneratorFactory.cs
@@ -25,7 +25,6 @@ namespace Ninject.Extensions.Conventions.BindingBuilder
     using System.Linq;
     using System.Text.RegularExpressions;
 
-    using Ninject.Components;
     using Ninject.Extensions.Conventions.BindingGenerators;
     using Ninject.Extensions.Conventions.Syntax;
 #if !SILVERLIGHT_20 && !WINDOWS_PHONE && !NETCF_35
@@ -49,6 +48,16 @@ namespace Ninject.Extensions.Conventions.BindingBuilder
         public BindingGeneratorFactory(IBindableTypeSelector bindableTypeSelector)
         {
             this.bindableTypeSelector = bindableTypeSelector;
+        }
+
+        /// <summary>
+        /// Creates a specific types binding generator.
+        /// </summary>
+        /// <param name="serviceTypes">The service types the generator should create bindings for.</param>
+        /// <returns>The newly created generator.</returns>
+        public IBindingGenerator CreateSpecificTypesBindingGenerator(params Type[] serviceTypes)
+        {
+            return new SpecificTypesBindingGenerator(serviceTypes);
         }
 
         /// <summary>

--- a/src/Ninject.Extensions.Conventions/BindingBuilder/ConventionSyntax.Bind.cs
+++ b/src/Ninject.Extensions.Conventions/BindingBuilder/ConventionSyntax.Bind.cs
@@ -59,6 +59,26 @@ namespace Ninject.Extensions.Conventions.BindingBuilder
         }
 
         /// <summary>
+        /// Binds <typeparamref name="T"/> to the type.
+        /// </summary>
+        /// <typeparam name="T">The type to bind.</typeparam>
+        /// <returns>The fluent syntax</returns>
+        public IConfigureSyntax Bind<T>()
+        {
+            return this.Bind(typeof(T));
+        }
+
+        /// <summary>
+        /// Binds <paramref name="types"/> to the type.
+        /// </summary>
+        /// <param name="types">The types to bind.</param>
+        /// <returns>The fluent syntax</returns>
+        public IConfigureSyntax Bind(params Type[] types)
+        {
+            return this.BindWith(this.bindingGeneratorFactory.CreateSpecificTypesBindingGenerator(types));
+        }
+
+        /// <summary>
         /// Binds all interfaces of the given types to the type.
         /// </summary>
         /// <returns>The fluent syntax</returns>

--- a/src/Ninject.Extensions.Conventions/BindingBuilder/IBindingGeneratorFactory.cs
+++ b/src/Ninject.Extensions.Conventions/BindingBuilder/IBindingGeneratorFactory.cs
@@ -24,7 +24,6 @@ namespace Ninject.Extensions.Conventions.BindingBuilder
     using System;
     using System.Text.RegularExpressions;
 
-    using Ninject.Components;
     using Ninject.Extensions.Conventions.BindingGenerators;
     using Ninject.Extensions.Conventions.Syntax;
 #if !SILVERLIGHT_20 && !WINDOWS_PHONE && !NETCF_35
@@ -36,6 +35,13 @@ namespace Ninject.Extensions.Conventions.BindingBuilder
     /// </summary>
     public interface IBindingGeneratorFactory
     {
+        /// <summary>
+        /// Creates a specific types binding generator.
+        /// </summary>
+        /// <param name="serviceTypes">The service types the generator should create bindings for.</param>
+        /// <returns>The newly created generator.</returns>
+        IBindingGenerator CreateSpecificTypesBindingGenerator(params Type[] serviceTypes);
+
         /// <summary>
         /// Creates a regex binding generator.
         /// </summary>

--- a/src/Ninject.Extensions.Conventions/BindingGenerators/SpecificTypesBindingGenerator.cs
+++ b/src/Ninject.Extensions.Conventions/BindingGenerators/SpecificTypesBindingGenerator.cs
@@ -1,0 +1,74 @@
+﻿namespace Ninject.Extensions.Conventions.BindingGenerators
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Globalization;
+    using System.Linq;
+    using System.Text;
+    using Ninject.Syntax;
+
+    /// <summary>
+    /// Binds the type to all specified service types.
+    /// </summary>
+    public class SpecificTypesBindingGenerator : IBindingGenerator
+    {
+        private readonly Type[] serviceTypes;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SpecificTypesBindingGenerator"/> class.
+        /// </summary>
+        /// <param name="serviceTypes">The service types the bindings should be created for.</param>
+        public SpecificTypesBindingGenerator(Type[] serviceTypes)
+        {
+            this.serviceTypes = serviceTypes;
+        }
+
+        /// <summary>
+        /// Creates the bindings for a type.
+        /// </summary>
+        /// <param name="type">The type for which the bindings are created.</param>
+        /// <param name="bindingRoot">The binding root that is used to create the bindings.</param>
+        /// <returns>
+        /// The syntaxes of the created bindings to configure more options.
+        /// </returns>
+        public IEnumerable<IBindingWhenInNamedWithOrOnSyntax<object>> CreateBindings(Type type, IBindingRoot bindingRoot)
+        {
+            if (bindingRoot == null)
+            {
+                throw new ArgumentNullException("bindingRoot");
+            }
+
+            this.AssertTypeImplementsServiceTypes(type);
+
+            return new[]
+            {
+                bindingRoot.Bind(this.serviceTypes).To(type)
+            };
+        }
+
+        private void AssertTypeImplementsServiceTypes(Type type)
+        {
+            var notImplementedServiceTypes = this.serviceTypes
+                .Where(serviceType => !serviceType.IsAssignableFrom(type))
+                .ToList();
+
+            if (notImplementedServiceTypes.Any())
+            {
+                var stringBuilder = new StringBuilder();
+                stringBuilder
+                    .AppendFormat(CultureInfo.InvariantCulture, "The type '{0}' does not implement the following service types: ", type.FullName)
+                    .AppendLine();
+
+                foreach (Type serviceType in notImplementedServiceTypes)
+                {
+                    stringBuilder
+                        .AppendFormat(CultureInfo.InvariantCulture, " - {0}", serviceType)
+                        .AppendLine();
+                }
+
+                stringBuilder.Append("Fix your binding to only bind service types which are implemented.");
+                throw new InvalidOperationException(stringBuilder.ToString());
+            }
+        }
+    }
+}

--- a/src/Ninject.Extensions.Conventions/Ninject.Extensions.Conventions.csproj
+++ b/src/Ninject.Extensions.Conventions/Ninject.Extensions.Conventions.csproj
@@ -112,6 +112,7 @@
     <Compile Include="BindingGenerators\SelectorBindingGenerator.cs" />
     <Compile Include="BindingGenerators\SelfBindingGenerator.cs" />
     <Compile Include="BindingGenerators\SingleInterfaceBindingGenerator.cs" />
+    <Compile Include="BindingGenerators\SpecificTypesBindingGenerator.cs" />
     <Compile Include="Extensions\ExtensionsForIKernel.cs" />
     <Compile Include="Extensions\ExtensionsForAssembly.cs" />
     <Compile Include="BindingBuilder\ConventionSyntax.cs" />

--- a/src/Ninject.Extensions.Conventions/Syntax/IBindSyntax.cs
+++ b/src/Ninject.Extensions.Conventions/Syntax/IBindSyntax.cs
@@ -61,6 +61,20 @@ namespace Ninject.Extensions.Conventions.Syntax
         IConfigureSyntax BindWith(IBindingGenerator generator);
 
         /// <summary>
+        /// Binds <typeparamref name="T"/> to the type.
+        /// </summary>
+        /// <typeparam name="T">The type to bind.</typeparam>
+        /// <returns>The fluent syntax</returns>
+        IConfigureSyntax Bind<T>();
+
+        /// <summary>
+        /// Binds <paramref name="types"/> to the type.
+        /// </summary>
+        /// <param name="types">The types to bind.</param>
+        /// <returns>The fluent syntax</returns>
+        IConfigureSyntax Bind(params Type[] types);
+
+        /// <summary>
         /// Binds all interfaces of the given types to the type.
         /// </summary>
         /// <returns>The fluent syntax</returns>


### PR DESCRIPTION
We would like to have `IBindSyntax.Bind<>` syntax to bind a specific interface, like:

```
IBindingRoot.Bind(x => x
         .FromCurrentAssembly()
         .SelectAllClasses()
         .InheritingFrom<IFoo>
         .Bind<IFoo>);
```

Hint:
- The pull request also contains `IBindSyntax.Bind(params Type[] serviceTypes)`. We don't need that but i felt i wouldn't make it more complex. If you think it only blows up the syntax interface without generating adequate benefit feel free to remove it (or tell me to remove it ;-) ).
  - This required adapting the kernel mock in order to be able to test `.Bind(typeof(IFoo), typeof(IBar)).To(typeof(FooBar))` style bindings.
-  Also i did not base it on `IBindSyntax.BindSelection(...)` since i felt it makes it more complicated then necessary. But if you insist on it i will adapt the pull requeset ;-).
