### PR TITLE
Add IFromSyntax.FromAssembliesMatching() with filter

### DIFF
--- a/ReleaseNotes.txt
+++ b/ReleaseNotes.txt
@@ -1,3 +1,11 @@
+Version 3.2.0.1
+-------------
+- Add: Support for combination of assembly pattern matching and filter
+  i.e.
+  kernel.Bind(x => x
+     .FromAssembliesMatching(IEnumerable<string> patterns, Predicate<Assembly> filter)
+	 ...);
+
 Version 3.2.0
 -------------
 - Add: Support for multiple configurations in one BindWith

--- a/src/Ninject.Extensions.Conventions.Test/BindingBuilder/ConventionSyntaxFromTests.cs
+++ b/src/Ninject.Extensions.Conventions.Test/BindingBuilder/ConventionSyntaxFromTests.cs
@@ -212,6 +212,22 @@ namespace Ninject.Extensions.Conventions.BindingBuilder
 
             this.conventionBindingBuilderMock.Verify(b => b.SelectAllTypesFrom(IsMatchingSequence(assemblies)));
         }
+
+        [Fact]
+        public void FromAssembliesMatchingWithFilter_CallBuilder_WithAllAssembliesGivenByTheAssemblyFinder()
+        {
+            Predicate<Assembly> filter = a => true;
+            var patterns = new[] { "Pattern1", "Pattern2" };
+            var assemblyNames = new[] { "Assembly" };
+            var assemblies = new[] { Assembly.GetCallingAssembly() };
+
+            this.SetupFindAssembliesMatching(assemblyNames, patterns);
+            this.SetupFindAssemblies(filter, assemblies, assemblyNames);
+
+            this.testee.FromAssembliesMatching(patterns.AsEnumerable(), filter);
+
+            this.conventionBindingBuilderMock.Verify(b => b.SelectAllTypesFrom(IsMatchingSequence(assemblies)));
+        }
 #endif
 
 #if !NO_SKIP_VISIBILITY

--- a/src/Ninject.Extensions.Conventions/BindingBuilder/ConventionSyntax.From.cs
+++ b/src/Ninject.Extensions.Conventions/BindingBuilder/ConventionSyntax.From.cs
@@ -19,7 +19,6 @@
 // </copyright>
 //-------------------------------------------------------------------------------
 
-using System.Resources;
 
 namespace Ninject.Extensions.Conventions.BindingBuilder
 {
@@ -167,6 +166,17 @@ namespace Ninject.Extensions.Conventions.BindingBuilder
         public IIncludingNonePublicTypesSelectSyntax FromAssembliesMatching(IEnumerable<string> patterns)
         {
             return this.From(this.assemblyFinder.FindAssembliesMatching(patterns));
+        }
+
+        /// <summary>
+        /// Scans the assemblies matching the given pattern.
+        /// </summary>
+        /// <param name="patterns">The patterns to match the assemblies.</param>
+        /// <param name="filter">The filter for filtering the assemblies.</param>
+        /// <returns>The fluent syntax.</returns>
+        public IIncludingNonePublicTypesSelectSyntax FromAssembliesMatching(IEnumerable<string> patterns, Predicate<Assembly> filter)
+        {
+            return this.From(this.assemblyFinder.FindAssembliesMatching(patterns), filter);
         }
 #endif
     }

--- a/src/Ninject.Extensions.Conventions/Syntax/IFromSyntax.cs
+++ b/src/Ninject.Extensions.Conventions/Syntax/IFromSyntax.cs
@@ -126,6 +126,14 @@ namespace Ninject.Extensions.Conventions.Syntax
         /// <param name="patterns">The patterns to match the assemblies.</param>
         /// <returns>The fluent syntax.</returns>
         IIncludingNonePublicTypesSelectSyntax FromAssembliesMatching(IEnumerable<string> patterns);
+
+        /// <summary>
+        /// Scans the assemblies that matching one of the given assembly name pattern.
+        /// </summary>
+        /// <param name="patterns">The patterns to match the assemblies.</param>
+        /// <param name="filter">The filter for filtering the assemblies.</param>
+        /// <returns>The fluent syntax.</returns>
+        IIncludingNonePublicTypesSelectSyntax FromAssembliesMatching(IEnumerable<string> patterns, Predicate<Assembly> filter);
 #endif        
     }
 }


### PR DESCRIPTION
Add
FromAssembliesMatching(IEnumerable<string> patterns, Predicate<Assembly> filter)

so that we can achieve:

Select All Assemblies
Starting with "SomeProduct.Name"
But not (ending with ".Test" or ".Specification").
