### PR TITLE
Scope configuration with attributes

### DIFF
--- a/src/Ninject.Extensions.Conventions.Test/Fakes/ServiceWithMultipleScopes.cs
+++ b/src/Ninject.Extensions.Conventions.Test/Fakes/ServiceWithMultipleScopes.cs
@@ -1,0 +1,32 @@
+﻿//-------------------------------------------------------------------------------
+// <copyright file="ServiceWithMultipleScopes.cs" company="Ninject Project Contributors">
+//   Copyright (c) 2009-2011 Ninject Project Contributors
+//   Authors: Dominik Schlosser (dominik.schlosser@gmail.com)
+//           
+//   Dual-licensed under the Apache License, Version 2.0, and the Microsoft Public License (Ms-PL).
+//   you may not use this file except in compliance with one of the Licenses.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//   or
+//       http://www.microsoft.com/opensource/licenses.mspx
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+// </copyright>
+//-------------------------------------------------------------------------------
+
+using Ninject.Extensions.Conventions.Attributes;
+
+namespace Ninject.Extensions.Conventions.Fakes
+{
+    [TransientScoped]
+    [ThreadScoped]
+    [SingletonScoped]
+    public class ServiceWithMultipleScopes
+    {
+    }
+}

--- a/src/Ninject.Extensions.Conventions.Test/Fakes/SingletonScopedService.cs
+++ b/src/Ninject.Extensions.Conventions.Test/Fakes/SingletonScopedService.cs
@@ -1,0 +1,30 @@
+﻿//-------------------------------------------------------------------------------
+// <copyright file="SingletonScopedService.cs" company="Ninject Project Contributors">
+//   Copyright (c) 2009-2011 Ninject Project Contributors
+//   Authors: Dominik Schlosser (dominik.schlosser@gmail.com)
+//           
+//   Dual-licensed under the Apache License, Version 2.0, and the Microsoft Public License (Ms-PL).
+//   you may not use this file except in compliance with one of the Licenses.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//   or
+//       http://www.microsoft.com/opensource/licenses.mspx
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+// </copyright>
+//-------------------------------------------------------------------------------
+
+using Ninject.Extensions.Conventions.Attributes;
+
+namespace Ninject.Extensions.Conventions.Fakes
+{
+    [SingletonScoped]
+    public class SingletonScopedService : ThreadScopedService
+    {
+    }
+}

--- a/src/Ninject.Extensions.Conventions.Test/Fakes/ThreadScopedService.cs
+++ b/src/Ninject.Extensions.Conventions.Test/Fakes/ThreadScopedService.cs
@@ -1,0 +1,30 @@
+﻿//-------------------------------------------------------------------------------
+// <copyright file="ThreadScopedService.cs" company="Ninject Project Contributors">
+//   Copyright (c) 2009-2011 Ninject Project Contributors
+//   Authors: Dominik Schlosser (dominik.schlosser@gmail.com)
+//           
+//   Dual-licensed under the Apache License, Version 2.0, and the Microsoft Public License (Ms-PL).
+//   you may not use this file except in compliance with one of the Licenses.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//   or
+//       http://www.microsoft.com/opensource/licenses.mspx
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+// </copyright>
+//-------------------------------------------------------------------------------
+
+using Ninject.Extensions.Conventions.Attributes;
+
+namespace Ninject.Extensions.Conventions.Fakes
+{
+    [ThreadScoped]
+    public class ThreadScopedService
+    {
+    }
+}

--- a/src/Ninject.Extensions.Conventions.Test/Fakes/TransientScopedService.cs
+++ b/src/Ninject.Extensions.Conventions.Test/Fakes/TransientScopedService.cs
@@ -1,0 +1,30 @@
+﻿//-------------------------------------------------------------------------------
+// <copyright file="TransientScopedService.cs" company="Ninject Project Contributors">
+//   Copyright (c) 2009-2011 Ninject Project Contributors
+//   Authors: Dominik Schlosser (dominik.schlosser@gmail.com)
+//           
+//   Dual-licensed under the Apache License, Version 2.0, and the Microsoft Public License (Ms-PL).
+//   you may not use this file except in compliance with one of the Licenses.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//   or
+//       http://www.microsoft.com/opensource/licenses.mspx
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+// </copyright>
+//-------------------------------------------------------------------------------
+
+using Ninject.Extensions.Conventions.Attributes;
+
+namespace Ninject.Extensions.Conventions.Fakes
+{
+    [TransientScoped]
+    public class TransientScopedService
+    {
+    }
+}

--- a/src/Ninject.Extensions.Conventions.Test/Ninject.Extensions.Conventions.Tests.csproj
+++ b/src/Ninject.Extensions.Conventions.Test/Ninject.Extensions.Conventions.Tests.csproj
@@ -144,6 +144,10 @@
     <Compile Include="Fakes\IMultipleInterfaceCrazyService.cs" />
     <Compile Include="Fakes\IService.cs" />
     <Compile Include="Fakes\MultipleInterfaceCrazyService.cs" />
+    <Compile Include="Fakes\ServiceWithMultipleScopes.cs" />
+    <Compile Include="Fakes\TransientScopedService.cs" />
+    <Compile Include="Fakes\ThreadScopedService.cs" />
+    <Compile Include="Fakes\SingletonScopedService.cs" />
     <Compile Include="Fakes\TestAttribute.cs" />
     <Compile Include="IntegrationTests\AssemblyLoadingTests.cs" />
     <Compile Include="IntegrationTests\ConfigurationTests.cs" />

--- a/src/Ninject.Extensions.Conventions/Attributes/ScopeAttribute.cs
+++ b/src/Ninject.Extensions.Conventions/Attributes/ScopeAttribute.cs
@@ -1,0 +1,32 @@
+﻿//-------------------------------------------------------------------------------
+// <copyright file="ScopeAttribute.cs" company="Ninject Project Contributors">
+//   Copyright (c) 2009-2011 Ninject Project Contributors
+//   Authors: Dominik Schlosser (dominik.schlosser@gmail.com)
+//           
+//   Dual-licensed under the Apache License, Version 2.0, and the Microsoft Public License (Ms-PL).
+//   you may not use this file except in compliance with one of the Licenses.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//   or
+//       http://www.microsoft.com/opensource/licenses.mspx
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+// </copyright>
+//-------------------------------------------------------------------------------
+
+using System;
+using Ninject.Syntax;
+
+namespace Ninject.Extensions.Conventions.Attributes
+{
+    [AttributeUsage(AttributeTargets.Class, Inherited = true)]
+    public abstract class ScopeAttribute : Attribute
+    {
+        public abstract void Configure(IBindingWhenInNamedWithOrOnSyntax<object> binding);
+    }
+}

--- a/src/Ninject.Extensions.Conventions/Attributes/SingletonScopedAttribute.cs
+++ b/src/Ninject.Extensions.Conventions/Attributes/SingletonScopedAttribute.cs
@@ -1,0 +1,33 @@
+﻿//-------------------------------------------------------------------------------
+// <copyright file="SingletonScopedAttribute.cs" company="Ninject Project Contributors">
+//   Copyright (c) 2009-2011 Ninject Project Contributors
+//   Authors: Dominik Schlosser (dominik.schlosser@gmail.com)
+//           
+//   Dual-licensed under the Apache License, Version 2.0, and the Microsoft Public License (Ms-PL).
+//   you may not use this file except in compliance with one of the Licenses.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//   or
+//       http://www.microsoft.com/opensource/licenses.mspx
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+// </copyright>
+//-------------------------------------------------------------------------------
+
+using Ninject.Syntax;
+
+namespace Ninject.Extensions.Conventions.Attributes
+{
+    public class SingletonScopedAttribute : ScopeAttribute
+    {
+        public override void Configure(IBindingWhenInNamedWithOrOnSyntax<object> binding)
+        {
+            binding.InSingletonScope();
+        }
+    }
+}

--- a/src/Ninject.Extensions.Conventions/Attributes/ThreadScopedAttribute.cs
+++ b/src/Ninject.Extensions.Conventions/Attributes/ThreadScopedAttribute.cs
@@ -1,0 +1,33 @@
+﻿//-------------------------------------------------------------------------------
+// <copyright file="ThreadScopedAttribute.cs" company="Ninject Project Contributors">
+//   Copyright (c) 2009-2011 Ninject Project Contributors
+//   Authors: Dominik Schlosser (dominik.schlosser@gmail.com)
+//           
+//   Dual-licensed under the Apache License, Version 2.0, and the Microsoft Public License (Ms-PL).
+//   you may not use this file except in compliance with one of the Licenses.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//   or
+//       http://www.microsoft.com/opensource/licenses.mspx
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+// </copyright>
+//-------------------------------------------------------------------------------
+
+using Ninject.Syntax;
+
+namespace Ninject.Extensions.Conventions.Attributes
+{
+    public class ThreadScopedAttribute : ScopeAttribute
+    {
+        public override void Configure(IBindingWhenInNamedWithOrOnSyntax<object> binding)
+        {
+            binding.InThreadScope();
+        }
+    }
+}

--- a/src/Ninject.Extensions.Conventions/Attributes/TransientScopedAttribute.cs
+++ b/src/Ninject.Extensions.Conventions/Attributes/TransientScopedAttribute.cs
@@ -1,0 +1,33 @@
+﻿//-------------------------------------------------------------------------------
+// <copyright file="TransientScopedAttribute.cs" company="Ninject Project Contributors">
+//   Copyright (c) 2009-2011 Ninject Project Contributors
+//   Authors: Dominik Schlosser (dominik.schlosser@gmail.com)
+//           
+//   Dual-licensed under the Apache License, Version 2.0, and the Microsoft Public License (Ms-PL).
+//   you may not use this file except in compliance with one of the Licenses.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//   or
+//       http://www.microsoft.com/opensource/licenses.mspx
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+// </copyright>
+//-------------------------------------------------------------------------------
+
+using Ninject.Syntax;
+
+namespace Ninject.Extensions.Conventions.Attributes
+{
+    public class TransientScopedAttribute : ScopeAttribute
+    {
+        public override void Configure(IBindingWhenInNamedWithOrOnSyntax<object> binding)
+        {
+            binding.InTransientScope();
+        }
+    }
+}

--- a/src/Ninject.Extensions.Conventions/BindingBuilder/ConventionBindingBuilder.cs
+++ b/src/Ninject.Extensions.Conventions/BindingBuilder/ConventionBindingBuilder.cs
@@ -19,6 +19,8 @@
 // </copyright>
 //-------------------------------------------------------------------------------
 
+using Ninject.Extensions.Conventions.Attributes;
+
 namespace Ninject.Extensions.Conventions.BindingBuilder
 {
     using System;
@@ -227,6 +229,26 @@ namespace Ninject.Extensions.Conventions.BindingBuilder
             foreach (var syntax in this.bindingSyntax[type])
             {
                 configuration(syntax, type);
+            }
+        }
+
+        /// <summary>
+        /// Evaluates scope attributes for all types.
+        /// </summary>
+        public void ConfigureScopesFromAttributes()
+        {
+            foreach (var bindingSyntaxEntry in this.bindingSyntax)
+            {
+                var scopeAttribute =
+                    bindingSyntaxEntry.Key.GetCustomAttributes(false).OfType<ScopeAttribute>().SingleOrDefault();
+
+                if (scopeAttribute != null)
+                {
+                    foreach (var syntax in bindingSyntaxEntry.Value)
+                    {
+                        scopeAttribute.Configure(syntax);
+                    }
+                }
             }
         }
 

--- a/src/Ninject.Extensions.Conventions/BindingBuilder/ConventionSyntax.Configure.cs
+++ b/src/Ninject.Extensions.Conventions/BindingBuilder/ConventionSyntax.Configure.cs
@@ -77,5 +77,15 @@ namespace Ninject.Extensions.Conventions.BindingBuilder
             this.bindingBuilder.Configure(configuration);
             return this;
         }
+
+        /// <summary>
+        /// Evaluates scope attributes for all types.
+        /// </summary>
+        /// <returns>The fluent syntax.</returns>
+        public IConfigureForSyntax ConfigureScopesFromAttributes()
+        {
+            this.bindingBuilder.ConfigureScopesFromAttributes();
+            return this;
+        }
     }
 }

--- a/src/Ninject.Extensions.Conventions/BindingBuilder/IConventionBindingBuilder.cs
+++ b/src/Ninject.Extensions.Conventions/BindingBuilder/IConventionBindingBuilder.cs
@@ -96,5 +96,10 @@ namespace Ninject.Extensions.Conventions.BindingBuilder
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1004:GenericMethodsShouldProvideTypeParameter",
             Justification = "Makes the API simpler.")]
         void ConfigureFor<T>(ConfigurationActionWithService configuration);
+
+        /// <summary>
+        /// Evaluates scope attributes for all types.
+        /// </summary>
+        void ConfigureScopesFromAttributes();
     }
 }

--- a/src/Ninject.Extensions.Conventions/Ninject.Extensions.Conventions.csproj
+++ b/src/Ninject.Extensions.Conventions/Ninject.Extensions.Conventions.csproj
@@ -80,6 +80,10 @@
     <Compile Include="..\SharedAssemblyInfo.cs">
       <Link>Properties\SharedAssemblyInfo.cs</Link>
     </Compile>
+    <Compile Include="Attributes\ScopeAttribute.cs" />
+    <Compile Include="Attributes\SingletonScopedAttribute.cs" />
+    <Compile Include="Attributes\ThreadScopedAttribute.cs" />
+    <Compile Include="Attributes\TransientScopedAttribute.cs" />
     <Compile Include="BindingBuilder\ConventionBindingBuilder.cs" />
     <Compile Include="BindingBuilder\ConventionSyntax.From.cs" />
     <Compile Include="BindingBuilder\ConventionSyntax.Select.cs" />

--- a/src/Ninject.Extensions.Conventions/Syntax/IConfigureSyntax.cs
+++ b/src/Ninject.Extensions.Conventions/Syntax/IConfigureSyntax.cs
@@ -39,5 +39,11 @@ namespace Ninject.Extensions.Conventions.Syntax
         /// <param name="configuration">The configuration.</param>
         /// <returns>The fluent syntax.</returns>
         IConfigureForSyntax Configure(ConfigurationActionWithService configuration);
+
+        /// <summary>
+        /// Evaluates scope attributes for all types.
+        /// </summary>
+        /// <returns>The fluent syntax.</returns>
+        IConfigureForSyntax ConfigureScopesFromAttributes();
     }
 }


### PR DESCRIPTION
Hi,

i have added attributes for the three default scopes (Singleton, Thread, Transient) and extended the configuration builder to auto-configure scopes by using these attributes.
This change is inspired by Java EE's Contexts and Dependency Injection (CDI) specification, where you are able to define contexts (scopes) via annotations.

Custom scopes can easily be included by implementing a new attribute which inherits from "ScopeAttribute" and implements its abstract method "Configure".